### PR TITLE
update dependencies to fix some vulnerabilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: node_js
 sudo: false
 node_js:
-  - "9"
-  - "8"
-  - "6"
+  - "15"
+  - "14"
+  - "12"
 matrix:
   allow_failures:
-    - node_js: "9"
+    - node_js: "15"
 
 before_install:
   # Upgrade npm to avoid semver issues

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "async": "~1.5.0",
     "spritesheet-templates": "^10.3.0",
     "spritesmith": "^3.4.0",
-    "underscore": "~1.4.2",
+    "underscore": "^1.13.1",
     "url2": "1.0.0"
   },
   "devDependencies": {
@@ -65,10 +65,10 @@
     "foundry-release-git": "~2.0.2",
     "foundry-release-npm": "~2.0.2",
     "get-pixels": "~3.2.3",
-    "gmsmith": "~1.0.0",
-    "grunt": "~0.4.2",
-    "grunt-cli": "~0.1.13",
-    "grunt-newer": "~0.8.0",
+    "gmsmith": "^1.2.0",
+    "grunt": "~1.4.0",
+    "grunt-cli": "~1.4.2",
+    "grunt-newer": "~1.3.0",
     "mocha": "~1.21.5",
     "rimraf": "~2.2.8",
     "shell-quote": "~1.6.1"


### PR DESCRIPTION
There are too many vulnerabilities to mention (> 40).

`npm audit` still shows a few vulnerabilities, but they need to be fixed by someone with a deeper understanding of grunt-spritesmith.